### PR TITLE
Add smoke tests to `kaggle/rcran`.

### DIFF
--- a/build
+++ b/build
@@ -6,9 +6,21 @@ exec 1> >(logger -s -p user.notice -t $0-rcran-$commit 2>&1)
 exec 2> >(logger -s -p user.error -t $0-rcran-$commit)
 
 docker pull rocker/hadleyverse
-docker build --rm --no-cache --cpu-period=100000 --cpu-quota=200000 -t kaggle/rcran .
+docker build --rm --no-cache --cpu-period=100000 --cpu-quota=200000 -t kaggle/rcran-build .
 
 # Verify 'convert' (ImageMagick) is available.
-docker run --rm -t --read-only --net=none kaggle/rcran convert --version
+docker run --rm -t --read-only --net=none kaggle/rcran-build convert --version
 
+rm -rf /tmp/rcran-build
+mkdir -p /tmp/rcran-build/tmp
+mkdir -p /tmp/rcran-build/devshm
+mkdir -p /tmp/rcran-build/working
+docker run --rm -t --read-only --net=none -e HOME=/tmp -v $PWD:/input:ro -v /tmp/rcran-build/working:/working -w=/working -v /tmp/rcran-build/tmp:/tmp -v /tmp/rcran-build/devshm:/dev/shm kaggle/rcran-build /bin/bash -c 'Rscript /input/test_build.R'
+
+# Verify expected test_build.R output is present.
+[ -s /tmp/rcran-build/working/plot1.png ]
+
+echo "ok"
+
+docker tag kaggle/rcran-build:latest kaggle/rcran:latest
 docker push kaggle/rcran

--- a/test_build.R
+++ b/test_build.R
@@ -1,0 +1,35 @@
+# Loosely based on http://www.kdnuggets.com/2015/06/top-20-r-packages.html
+
+Library <- function(libname){
+  print(libname)
+  suppressPackageStartupMessages(library(libname, character.only=TRUE))
+}
+
+Library("Rcpp")
+Library("gapminder")
+Library("ggplot2")
+Library("stringr")
+Library("plyr")
+Library("digest")
+Library("reshape2")
+Library("colorspace")
+Library("RColorBrewer")
+Library("scales")
+Library("labeling")
+Library("proto")
+Library("munsell")
+Library("gtable")
+Library("dichromat")
+Library("mime")
+Library("RCurl")
+Library("bitops")
+Library("zoo")
+Library("knitr")
+Library("dplyr")
+Library("readr")
+Library("tidyr")
+Library("randomForest")
+Library("xgboost")
+
+testPlot1 <- ggplot(data.frame(x=1:10,y=runif(10))) + aes(x=x,y=y) + geom_line()
+ggsave(testPlot1, filename="plot1.png")


### PR DESCRIPTION
This runs that portion of `kaggle/rstats`'s smoke tests that are supposed to be
satisfied by `kaggle/rcran`.  This reduces the chances of successful
`kaggle/rcran` builds actually being dead on arrival for `kaggle/rstats` builds
(/other potential uses), and provides more clear, immediate feedback when
testing changes to `kaggle/rcran`'s specification.