### PR TITLE
Automatically tag rcran image with latest on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
           set -exo pipefail
 
           date
-          ./push staging
+          ./push latest
         '''
       }
     }


### PR DESCRIPTION
Context: We deploy the `rstats` image to our worker. The `rstats` image uses this `rcran` image as its base image.

No need to manually verify this image before tagging it with `latest`. The deployment to our worker is gated for the `rstats` image. 

Next step is, once we have better tests, to automatically tag the `rstats` image with `latest` on a green run. This would give a full CD pipeline.