### PR TITLE
Fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM rocker/tidyverse:3.6.0
 
 RUN apt-get update && \
-    apt-get install -y imagemagick libudunits2-dev curl libgdal-dev libjpeg-dev
+    apt-get install -y imagemagick libudunits2-dev curl libgdal-dev \
+    libjpeg-dev libxt-dev
 
 # Install Rust and Cargo. Some R packages requires Rust.
 # See: b/113106905


### PR DESCRIPTION
Currently, Cairo installation is failing with:
```
xlib-backend.c:34:74: fatal error: X11/Intrinsic.h: No such file or directory
 #include <X11/Intrinsic.h>      /*->    Xlib.h  Xutil.h Xresource.h .. */
```

Adding the missing library.