### PR TITLE
Revert "Upgrade to R 3.6.2"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/tidyverse:3.6.2
+FROM rocker/tidyverse:3.6.0
 
 RUN apt-get update && \
     apt-get install -y imagemagick libudunits2-dev curl libgdal-dev \


### PR DESCRIPTION
Reverts Kaggle/docker-rcran#19

This change seems to break SDS workers down the line[0]. Because `rstats` needs to be deployed for another change and has other release test breakages since the last release (Nov 20th), I'm going to revert this change for now to try to clear up the release.

[0] http://shortn/_KJk9d7urfQ