### PR TITLE
Improve build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
   - build
   - --rm
   - --no-cache
-  - --tag=gcr.io/$PROJECT_ID/rcran-build:temp
+  - --tag=gcr.io/$PROJECT_ID/rcran-build:$BUILD_ID
   - .
 
 # Pushing the intermediate image can be useful to debug test failures.
@@ -14,17 +14,17 @@ steps:
   name: 'gcr.io/cloud-builders/docker'
   args:
   - push
-  - gcr.io/$PROJECT_ID/rcran-build:temp
+  - gcr.io/$PROJECT_ID/rcran-build:$BUILD_ID
 
 # Verify 'convert' (ImageMagick) is available.
 - id: 'test-convert'
   waitFor: ['intermediate-push'] # Otherwise the test failure should stop push.
-  name: 'gcr.io/$PROJECT_ID/rcran-build:temp'
+  name: 'gcr.io/$PROJECT_ID/rcran-build:$BUILD_ID'
   args: ['convert', '--version']
 
 - id: 'test'
   waitFor: ['intermediate-push'] # Otherwise the test failure should stop push.
-  name: 'gcr.io/$PROJECT_ID/rcran-build:temp'
+  name: 'gcr.io/$PROJECT_ID/rcran-build:$BUILD_ID'
   entrypoint: 'bash'
   args:
   - '-c'
@@ -40,7 +40,7 @@ steps:
   name: 'gcr.io/cloud-builders/docker'
   args:
   - tag
-  - gcr.io/$PROJECT_ID/rcran-build:temp
+  - gcr.io/$PROJECT_ID/rcran-build:$BUILD_ID
   - gcr.io/kaggle-images/rcran:$_TAG
 
 images: ['gcr.io/kaggle-images/rcran:$_TAG']

--- a/package_installs.R
+++ b/package_installs.R
@@ -3,7 +3,7 @@ REPO <- 'http://ftp.osuosl.org/pub/cran'
 
 # Number of parallel installs. 
 # Experimentally optimized. A too high value (128) crashes.
-M <- 64
+M <- 16
 
 # Make use of all CPUs available to the custom GCB VM size we use.
 options(Ncpus = 32)


### PR DESCRIPTION
Last week, I added a test to make sure `fable` was installed correctly. Tested on my own computer, it passed. But it doesn't on GCB.

The culprit seems to be the number of parallel package installations.
I [analyzed different scenarios](https://docs.google.com/spreadsheets/d/1N99nJUTHgonjAloGpxAGlekyCE0vLEMwpMME1iZzFvw/edit?usp=sharing) to find an optimum number installed packages / build duration. 
By reducing this number from `64` to `16`, 25% more packages end up installed (including `fable`), at the cost of an increased build time (5h43 instead of 3h18).

I also added the build id as unique docker tag instead of a common one.