### PR TITLE
Install the gg* packages by default, instead of installed in rstats build

### DIFF
--- a/packages
+++ b/packages
@@ -15,7 +15,10 @@ fable
 foreign
 fslr
 gapminder
+gganimate
 ggplot2
+ggraph
+ggthemes
 gridSVG
 gtable
 hrbrthemes


### PR DESCRIPTION
Note: they were already included in `packages_users` generated file