### PR TITLE
Include NNS package at R notebook

### DIFF
--- a/packages
+++ b/packages
@@ -39,6 +39,7 @@ mgcv
 mime
 munsell
 nnet
+NNS
 oro.dicom
 oro.nifti
 plyr


### PR DESCRIPTION
Hello folks

Could be possible include NNS package? (some non parametric models and statistics)

Some competitions require time to execute notebook (optiver), and install offline takes more than 20 minutes.

This lib is already a CRAN library

Thanks