### PR TITLE
Include NNS package at R notebook

### DIFF
--- a/packages_users
+++ b/packages_users
@@ -192,7 +192,8 @@ NMF
 NbClust                               
 NetworkComparisonTest                 
 NeuralNetTools                        
-NoiseFiltersR                         
+NoiseFiltersR
+NNS
 ORCI                                  
 OneR                                  
 OpenImageR                            


### PR DESCRIPTION
Hello folks

Could be possible include NNS package? (some non parametric models and statistics)

Some competitions require time to execute notebook (optiver), and install offline takes more than 20 minutes.

This lib is already a CRAN library

Thanks