### PR TITLE
Fix rstan installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM rocker/tidyverse:4.0.5
 
 RUN apt-get update && \
     apt-get install -y imagemagick libmagick++-dev libudunits2-dev curl libgdal-dev \
-    libjpeg-dev libxt-dev libprotobuf-dev protobuf-compiler libjq-dev libzmq3-dev
+    libjpeg-dev libxt-dev libprotobuf-dev protobuf-compiler libjq-dev libzmq3-dev \
+    libv8-dev libnode-dev
 
 # Install Rust and Cargo. Some R packages requires Rust.
 # See: b/113106905


### PR DESCRIPTION
Error from previous build: 

```
Step #0 - "build": -----------------------------[ ANTICONF ]-------------------------------
Step #0 - "build": Configuration failed to find the libv8 engine library. Try installing:
Step #0 - "build":  * deb: libv8-dev or libnode-dev (Debian / Ubuntu)
Step #0 - "build":  * rpm: v8-devel (Fedora, EPEL)
Step #0 - "build":  * brew: v8 (OSX)
Step #0 - "build":  * csw: libv8_dev (Solaris)
Step #0 - "build": Alternatively, on Linux (x86_64) or MacOS you can set environment variable:
Step #0 - "build":     DOWNLOAD_STATIC_LIBV8=1
Step #0 - "build": to automatically download a static version of libv8.
Step #0 - "build": To use a custom libv8, set INCLUDE_DIR and LIB_DIR manually via:
Step #0 - "build": R CMD INSTALL --configure-vars='INCLUDE_DIR=... LIB_DIR=...'
Step #0 - "build": ---------------------------[ ERROR MESSAGE ]----------------------------
Step #0 - "build": <stdin>:1:10: fatal error: v8.h: No such file or directory
Step #0 - "build": compilation terminated.
Step #0 - "build": ------------------------------------------------------------------------
```

http://b/203085030