### PR TITLE
Delete old rcran images

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,6 +8,17 @@ steps:
   - --tag=gcr.io/$PROJECT_ID/rcran-build:$BUILD_ID
   - .
 
+# Delete old images
+- id: 'delete-old-images'
+  name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    set -e
+    gcloud container images list-tags gcr.io/$PROJECT_ID/rcran-build --filter="NOT tags:latest timestamp.datetime < -P3M" --format='get(digest)' --limit 100 | xargs -I {} gcloud container images delete gcr.io/$PROJECT_ID/rcran-build@{} --quiet --force-delete-tags
+    gcloud container images list-tags gcr.io/kaggle-images/rcran --filter="NOT tags:latest timestamp.datetime < -P3M" --format='get(digest)' --limit 100 | xargs -I {} gcloud container images delete gcr.io/kaggle-images/rcran@{} --quiet --force-delete-tags
+
 # Pushing the intermediate image can be useful to debug test failures.
 - id: 'intermediate-push'
   waitFor: ['build']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,8 +16,8 @@ steps:
   - '-c'
   - |
     set -e
-    gcloud container images list-tags gcr.io/$PROJECT_ID/rcran-build --filter="NOT tags:latest timestamp.datetime < -P3M" --format='get(digest)' --limit 100 | xargs -I {} gcloud container images delete gcr.io/$PROJECT_ID/rcran-build@{} --quiet --force-delete-tags
-    gcloud container images list-tags gcr.io/kaggle-images/rcran --filter="NOT tags:latest timestamp.datetime < -P3M" --format='get(digest)' --limit 100 | xargs -I {} gcloud container images delete gcr.io/kaggle-images/rcran@{} --quiet --force-delete-tags
+    gcloud container images list-tags gcr.io/$PROJECT_ID/rcran-build --filter="NOT tags:latest timestamp.datetime < -P6M" --format='get(digest)' --limit 100 | xargs -I {} gcloud container images delete gcr.io/$PROJECT_ID/rcran-build@{} --quiet --force-delete-tags
+    gcloud container images list-tags gcr.io/kaggle-images/rcran --filter="NOT tags:latest timestamp.datetime < -P6M" --format='get(digest)' --limit 100 | xargs -I {} gcloud container images delete gcr.io/kaggle-images/rcran@{} --quiet --force-delete-tags
 
 # Pushing the intermediate image can be useful to debug test failures.
 - id: 'intermediate-push'


### PR DESCRIPTION
- Delete images w/o the latest tag.
- Delete images older than 3 months.
- Delete images in `kaggle-images` and `kkb-infra` projects.

http://b/208859194