### PR TITLE
Remove fslr package from RCRAN tests

### DIFF
--- a/packages
+++ b/packages
@@ -13,7 +13,6 @@ dplyr
 dtwclust
 fable
 foreign
-fslr
 gapminder
 gganimate
 ggplot2

--- a/test_build.R
+++ b/test_build.R
@@ -52,7 +52,7 @@ Library("zoo")
 #Packages for Neurohacking in R coursera course
 Library("oro.nifti")
 Library("oro.dicom")
-Library("fslr")
+# b/232137539 fslr is installed in rstats.
 
 testPlot1 <- ggplot(data.frame(x=1:10,y=runif(10))) + aes(x=x,y=y) + geom_line()
 ggsave(testPlot1, filename="plot1.png")


### PR DESCRIPTION
Install in rstats instead: https://github.com/Kaggle/docker-rstats/pull/186

The package was archived on RCRAN due to `neurobase` (one of its dependencies) being archived because of:

```
Archived on 2022-04-18 as 'coercion to logical' errors were not corrected in time.
```

http://b/232137539