### PR TITLE
Install libstdc++6 for scikit-learn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM rocker/tidyverse:4.0.5
 RUN apt-get update && \
     apt-get install -y imagemagick libmagick++-dev libudunits2-dev curl libgdal-dev \
     libjpeg-dev libxt-dev libprotobuf-dev protobuf-compiler libjq-dev libzmq3-dev \
-    libv8-dev libnode-dev
+    libv8-dev libnode-dev libstdc++6
 
 # Install Rust and Cargo. Some R packages requires Rust.
 # See: b/113106905


### PR DESCRIPTION
https://github.com/Kaggle/docker-rcran/issues/63

https://www.kaggle.com/discussions/product-feedback/341189