### PR TITLE
Fix many packages_users installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,32 @@ RUN apt-get update && \
 ADD rustup.sh rustup.sh
 RUN cat rustup.sh | sh -s -- -y
 
+ADD clean-layer.sh  /tmp/clean-layer.sh
+
+RUN apt-get update && \
+    apt-get install apt-transport-https && \
+    apt-get install -y -f r-cran-rgtk2 && \
+    apt-get install -y -f libv8-dev libgeos-dev libgdal-dev libproj-dev libsndfile1-dev \
+    libtiff5-dev fftw3 fftw3-dev libfftw3-dev libjpeg-dev libhdf4-0-alt libhdf4-alt-dev \
+    libhdf5-dev libx11-dev cmake libglu1-mesa-dev libgtk2.0-dev librsvg2-dev libxt-dev \
+    patch libgit2-dev && \
+    /tmp/clean-layer.sh
+
+RUN apt-get update && apt-get install -y build-essential git ninja-build ccache  libatlas-base-dev libopenblas-dev libopencv-dev python3-opencv && \
+    cd /usr/local/share && git clone --recursive --depth=1 --branch v1.8.x https://github.com/apache/incubator-mxnet.git mxnet && \
+    cd mxnet && cp config/linux.cmake config.cmake && rm -rf build && \
+    mkdir -p build && cd build && cmake .. && cmake --build . --parallel $(nproc) && \
+    cd .. && make -f R-package/Makefile rpkg && \
+    /tmp/clean-layer.sh
+
+    # Needed for "h5" library
+RUN apt-get install -y libhdf5-dev && \
+    # Needed for "topicmodels" library
+    apt-get install -y libgsl-dev && \
+    # Needed for "tesseract" library
+    apt-get install -y libpoppler-cpp-dev libtesseract-dev tesseract-ocr-eng && \
+    /tmp/clean-layer.sh
+
 ADD packages packages
 ADD packages_users packages_users
 ADD package_installs.R /tmp/package_installs.R

--- a/clean-layer.sh
+++ b/clean-layer.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# This scripts should be called at the end of each RUN command
+# in the Dockerfiles.
+#
+# Each RUN command creates a new layer that is stored separately.
+# At the end of each command, we should ensure we clean up downloaded
+# archives and source files used to produce binary to reduce the size
+# of the layer.
+set -e
+set -x
+
+# Delete files that pip caches when installing a package.
+rm -rf /root/.cache/pip/*
+# Delete old downloaded archive files 
+apt-get autoremove -y
+# Delete downloaded archive files
+apt-get clean
+# Delete source files used for building binaries
+rm -rf /usr/local/src/*


### PR DESCRIPTION
I noticed many packages used by users install just fine in the rstats image, but seem to fail in the rcran build. Moving some of the pre-setup from rstats into this image allows many packages to make it into the rcran image successfully.

Faliing before 226, after 141 (85 fixed).

http://b/245539960