### PR TITLE
Do not delete old unversioned images in CloudBuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,17 +8,6 @@ steps:
   - --tag=us-docker.pkg.dev/$PROJECT_ID/tools/rcran-build:$BUILD_ID
   - .
 
-# Delete old images
-- id: 'delete-old-images'
-  name: 'gcr.io/cloud-builders/gcloud'
-  entrypoint: 'bash'
-  args:
-  - '-c'
-  - |
-    set -e
-    gcloud container images list-tags us-docker.pkg.dev/$PROJECT_ID/tools/rcran-build:$BUILD_ID --filter="NOT tags:latest timestamp.datetime < -P6M" --format='get(digest)' --limit 100 | xargs -I {} gcloud container images delete us-docker.pkg.dev/$PROJECT_ID/tools/rcran-build@{} --quiet --force-delete-tags
-    gcloud container images list-tags gcr.io/kaggle-images/rcran --filter="NOT tags:latest timestamp.datetime < -P6M" --format='get(digest)' --limit 100 | xargs -I {} gcloud container images delete gcr.io/kaggle-images/rcran@{} --quiet --force-delete-tags
-
 # Pushing the intermediate image can be useful to debug test failures.
 - id: 'intermediate-push'
   waitFor: ['build']


### PR DESCRIPTION
Use new Artifact Registry cleanup policies feature instead.

http://b/321030221