### PR TITLE
R 4.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ ADD clean-layer.sh  /tmp/clean-layer.sh
 
 RUN apt-get update && \
     apt-get install apt-transport-https && \
-    apt-get install -y -f r-cran-rgtk2 && \
     apt-get install -y -f libv8-dev libgeos-dev libgdal-dev libproj-dev libsndfile1-dev \
     libtiff5-dev fftw3 fftw3-dev libfftw3-dev libjpeg-dev libhdf4-0-alt libhdf4-alt-dev \
     libhdf5-dev libx11-dev cmake libglu1-mesa-dev libgtk2.0-dev librsvg2-dev libxt-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,8 @@ RUN apt-get install -y libhdf5-dev && \
 ADD packages packages
 ADD packages_users packages_users
 ADD package_installs.R /tmp/package_installs.R
+ADD utils.R /tmp/utils.R
+
 RUN Rscript /tmp/package_installs.R && \
     bash -c "rm -Rf /tmp/Rtmp*"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/tidyverse:4.0.5
+FROM rocker/tidyverse:4.4.0
 
 RUN apt-get update && \
     apt-get install -y build-essential clang imagemagick libmagick++-dev libudunits2-dev curl libgdal-dev \

--- a/package_installs.R
+++ b/package_installs.R
@@ -1,50 +1,3 @@
-clean_up_dependencies <- function(x, available = NULL)
-{
-    ## x is a character vector of Depends / Suggests / Imports entries
-    ## returns a character vector of all the package dependencies mentioned
-    x <- x[!is.na(x)]
-    if(!length(x)) return(x)
-    x <- unlist(strsplit(x, ",", fixed = TRUE), use.names = FALSE)
-    unique(sub("^[[:space:]]*([[:alnum:].]+).*$", "\\1" , x))
-}
-
-make_dependency_list <- function(pkgs, available, dependencies = c("Depends", "Imports", "LinkingTo"), recursive = FALSE)
-{
-    ## given a character vector of packages,
-    ## return a named list of character vectors of their dependencies.
-    ## If recursive = TRUE, do this recursively.
-    if(!length(pkgs)) return(NULL)
-    if(is.null(available))
-        stop(gettextf("%s must be supplied", sQuote("available")), domain = NA)
-    info <- available[pkgs, dependencies, drop = FALSE]
-    x <- vector("list", length(pkgs)); names(x) <- pkgs
-    if(recursive) {
-        known <- row.names(available)
-        xx <- vector("list", length(known)); names(xx) <- known
-        info2 <-  available[, dependencies, drop = FALSE]
-        for (i in seq_along(known))
-            xx[[i]] <- clean_up_dependencies(info2[i, ])
-        for (i in pkgs) {
-            p <- xx[[i]]
-            p <- p[p %in% known]; p1 <- p
-            repeat {
-                extra <- unlist(xx[p1])
-                extra <- extra[extra != i]
-                extra <- extra[extra %in% known]
-                deps <- unique(c(p, extra))
-                if (length(deps) <= length(p)) break
-                p1 <- deps[!deps %in% p]
-                p <- deps
-            }
-            x[[i]] <- p
-        }
-    } else {
-        for (i in seq_along(pkgs)) x[[i]] <- clean_up_dependencies(info[i, ])
-    }
-    x
-}
-
-
 # Repo to pull package data and metadata from.
 REPO <- 'http://cran.us.r-project.org'
 options(repos = c("CRAN" = REPO))
@@ -109,6 +62,7 @@ alreadyInstalled <- function(pkg){
 }
 vecAlreadyInstalled <- Vectorize(alreadyInstalled)
 
+source('utils.R')
 print("Generating dependency list...")
 dl <- make_dependency_list(pkgs, allPackages, recursive = TRUE)
 dl <- dl[!vecAlreadyInstalled(names(dl))]

--- a/package_installs.R
+++ b/package_installs.R
@@ -62,7 +62,7 @@ alreadyInstalled <- function(pkg){
 }
 vecAlreadyInstalled <- Vectorize(alreadyInstalled)
 
-source('utils.R')
+source('/tmp/utils.R')
 print("Generating dependency list...")
 dl <- make_dependency_list(pkgs, allPackages, recursive = TRUE)
 dl <- dl[!vecAlreadyInstalled(names(dl))]

--- a/package_installs.R
+++ b/package_installs.R
@@ -64,7 +64,7 @@ vecAlreadyInstalled <- Vectorize(alreadyInstalled)
 
 source('/tmp/utils.R')
 print("Generating dependency list...")
-dl <- make_dependency_list(pkgs, allPackages, recursive = TRUE)
+dl <- make_dependency_list(pkgs, allPackages)
 dl <- dl[!vecAlreadyInstalled(names(dl))]
 dl <- lapply(dl, function(x) x[x %in% names(dl)])
 lens <- sapply(dl, length)

--- a/package_installs.R
+++ b/package_installs.R
@@ -8,10 +8,7 @@ clean_up_dependencies <- function(x, available = NULL)
     unique(sub("^[[:space:]]*([[:alnum:].]+).*$", "\\1" , x))
 }
 
-make_dependency_list <-
-    function(pkgs, available,
-             dependencies = c("Depends", "Imports", "LinkingTo"),
-             recursive = FALSE)
+make_dependency_list <- function(pkgs, available, dependencies = c("Depends", "Imports", "LinkingTo"), recursive = FALSE)
 {
     ## given a character vector of packages,
     ## return a named list of character vectors of their dependencies.

--- a/package_installs.R
+++ b/package_installs.R
@@ -26,7 +26,7 @@ make_dependency_list <-
         xx <- vector("list", length(known)); names(xx) <- known
         info2 <-  available[, dependencies, drop = FALSE]
         for (i in seq_along(known))
-            xx[[i]] <- .clean_up_dependencies(info2[i, ])
+            xx[[i]] <- clean_up_dependencies(info2[i, ])
         for (i in pkgs) {
             p <- xx[[i]]
             p <- p[p %in% known]; p1 <- p
@@ -42,7 +42,7 @@ make_dependency_list <-
             x[[i]] <- p
         }
     } else {
-        for (i in seq_along(pkgs)) x[[i]] <- .clean_up_dependencies(info[i, ])
+        for (i in seq_along(pkgs)) x[[i]] <- clean_up_dependencies(info[i, ])
     }
     x
 }
@@ -113,7 +113,7 @@ alreadyInstalled <- function(pkg){
 vecAlreadyInstalled <- Vectorize(alreadyInstalled)
 
 print("Generating dependency list...")
-dl <- utils:::.make_dependency_list(pkgs, allPackages, recursive = TRUE)
+dl <- make_dependency_list(pkgs, allPackages, recursive = TRUE)
 dl <- dl[!vecAlreadyInstalled(names(dl))]
 dl <- lapply(dl, function(x) x[x %in% names(dl)])
 lens <- sapply(dl, length)

--- a/package_installs.R
+++ b/package_installs.R
@@ -1,3 +1,53 @@
+clean_up_dependencies <- function(x, available = NULL)
+{
+    ## x is a character vector of Depends / Suggests / Imports entries
+    ## returns a character vector of all the package dependencies mentioned
+    x <- x[!is.na(x)]
+    if(!length(x)) return(x)
+    x <- unlist(strsplit(x, ",", fixed = TRUE), use.names = FALSE)
+    unique(sub("^[[:space:]]*([[:alnum:].]+).*$", "\\1" , x))
+}
+
+make_dependency_list <-
+    function(pkgs, available,
+             dependencies = c("Depends", "Imports", "LinkingTo"),
+             recursive = FALSE)
+{
+    ## given a character vector of packages,
+    ## return a named list of character vectors of their dependencies.
+    ## If recursive = TRUE, do this recursively.
+    if(!length(pkgs)) return(NULL)
+    if(is.null(available))
+        stop(gettextf("%s must be supplied", sQuote("available")), domain = NA)
+    info <- available[pkgs, dependencies, drop = FALSE]
+    x <- vector("list", length(pkgs)); names(x) <- pkgs
+    if(recursive) {
+        known <- row.names(available)
+        xx <- vector("list", length(known)); names(xx) <- known
+        info2 <-  available[, dependencies, drop = FALSE]
+        for (i in seq_along(known))
+            xx[[i]] <- .clean_up_dependencies(info2[i, ])
+        for (i in pkgs) {
+            p <- xx[[i]]
+            p <- p[p %in% known]; p1 <- p
+            repeat {
+                extra <- unlist(xx[p1])
+                extra <- extra[extra != i]
+                extra <- extra[extra %in% known]
+                deps <- unique(c(p, extra))
+                if (length(deps) <= length(p)) break
+                p1 <- deps[!deps %in% p]
+                p <- deps
+            }
+            x[[i]] <- p
+        }
+    } else {
+        for (i in seq_along(pkgs)) x[[i]] <- .clean_up_dependencies(info[i, ])
+    }
+    x
+}
+
+
 # Repo to pull package data and metadata from.
 REPO <- 'http://cran.us.r-project.org'
 options(repos = c("CRAN" = REPO))

--- a/utils.R
+++ b/utils.R
@@ -1,0 +1,50 @@
+# Based on private methods found in utils package
+# https://github.com/wch/r-source/blob/05bfe40425384c06ac179f64cd1060f04088064a/src/library/utils/R/packages.R#L1103
+
+clean_up_dependencies <- function(x)
+{
+    ## x is a character vector of Depends / Suggests / Imports entries
+    ## returns a character vector of all the package dependencies mentioned
+    x <- x[!is.na(x)]
+    if(!length(x)) return(x)
+    x <- unlist(strsplit(x, ",", fixed = TRUE), use.names = FALSE)
+    unique(sub("^[[:space:]]*([[:alnum:].]+).*$", "\\1" , x))
+}
+
+make_dependency_list <- function(pkgs, available)
+{
+    ## given a character vector of packages,
+    ## return a named list of character vectors of their dependencies.
+    entries <- c("Depends", "Imports", "LinkingTo")
+
+    if(!length(pkgs)) return(NULL)
+    if(is.null(available))
+        stop(gettextf("%s must be supplied", sQuote("available")), domain = NA)
+        
+    dependencies <- vector("list", length(pkgs)); names(dependencies) <- pkgs
+    
+    known_packages <- row.names(available)
+    info <-  available[, entries, drop = FALSE]
+
+    known_packages_with_dep <- vector("list", length(known_packages)); names(xx) <- known_packages
+    for (i in seq_along(known_packages))
+        known_packages_with_dep[[i]] <- clean_up_dependencies(info[i, ])
+
+    # Dependency Discovery, find the dependencies of the dependencies
+    for (pkg in pkgs) {
+        p <- known_packages_with_dep[[pkg]]
+        p <- p[p %in% known_packages]; p1 <- p
+        repeat {
+            extra <- unlist(known_packages_with_dep[p1])
+            extra <- extra[extra != pkg]
+            extra <- extra[extra %in% known_packages]
+            deps <- unique(c(p, extra))
+            if (length(deps) <= length(p)) break
+            p1 <- deps[!deps %in% p]
+            p <- deps
+        }
+        dependencies[[pkg]] <- p
+    }
+
+    dependencies
+}

--- a/utils.R
+++ b/utils.R
@@ -26,7 +26,7 @@ make_dependency_list <- function(pkgs, available)
     known_packages <- row.names(available)
     info <-  available[, entries, drop = FALSE]
 
-    known_packages_with_dep <- vector("list", length(known_packages)); names(xx) <- known_packages
+    known_packages_with_dep <- vector("list", length(known_packages)); names(known_packages_with_dep) <- known_packages
     for (i in seq_along(known_packages))
         known_packages_with_dep[[i]] <- clean_up_dependencies(info[i, ])
 


### PR DESCRIPTION
This is to update the image to use R 4.4.0,

we used an internal method from the util package to list dependencies, seem like a refactor happened that cause the pipeline to break. the refactor seem minimal (it was to speed up windows installs), but i couldn't seem to decipher what datatype it wanted. 

Easiest path forward is to integrate the old algo. into our image, and not depend on an internal method.  cleaned it up to make it readable. 
https://b.corp.google.com/issues/282922446

passed build in commit, [aa5cf28](https://github.com/Kaggle/docker-rcran/pull/79/commits/aa5cf285df9fac5b744151f45d63d813afd74bf3)

 I'm new to r, bear with me


#chavezcalderon-q2-fixit